### PR TITLE
Make LAUNCH-PRESENTER work on MacOS and Linux too

### DIFF
--- a/src/launch.lisp
+++ b/src/launch.lisp
@@ -2,35 +2,20 @@
 
 (in-package #:clotho)
 
-#+darwin
-(defun launch-presenter ()
-  ;; TODO: use find-port to get an open port, pass it to the Electron process on launch
-  (setf *remote-js-context* (remote-js:make-context :port *websocket-port*))
-  (setf *http-server* (make-instance 'hunchentoot:easy-acceptor :port *http-port*))
-  (hunchentoot:start *http-server*)
-  (remote-js:start *remote-js-context*)
-  (let* ((exepath "presenter/presenter-darwin-x64/presenter.app/Contents/MacOS/presenter")
-         (presenter-path (namestring (asdf:system-relative-pathname :clotho exepath))))
-    (setf *presenter* (uiop:launch-program presenter-path))))
+(defun exepath ()
+  #+darwin
+  "presenter/presenter-darwin-x64/presenter.app/Contents/MacOS/presenter"
+  #+linux
+  "presenter/presenter-linux-x64/presenter"
+  #+win32
+  "presenter/presenter-win32-x64/presenter.exe")
 
-#+linux
-(defun launch-presenter ()
-  ;; TODO: use find-port to get an open port, pass it to the Electron process on launch
-  (setf *remote-js-context* (remote-js:make-context :port *websocket-port*))
-  (setf *http-server* (make-instance 'hunchentoot:easy-acceptor :port *http-port*))
-  (hunchentoot:start *http-server*)
-  (remote-js:start *remote-js-context*)
-  (let* ((exepath "presenter/presenter-linux-x64/presenter.exe")
-         (presenter-path (namestring (asdf:system-relative-pathname :clotho exepath))))
-    (setf *presenter* (uiop:launch-program presenter-path))))
-
-#+win32
 (defun launch-presenter ()
   (let ((document-root-path (asdf:system-relative-pathname :clotho "resources/"))
         (error-template-path (asdf:system-relative-pathname :clotho "resources/errors/")))
     (setf *http-port* (get-available-port))
     (log-message "*http-port* set to ~S" *http-port*)
-    
+
     (setf *websocket-port* (get-available-port))
     (log-message "*websocket-port* set to ~S" *websocket-port*)
 
@@ -49,7 +34,7 @@
     (remote-js:start *remote-js-context*)
     (log-message "remote-js context started")
 
-    (let* ((exepath "presenter/presenter-win32-x64/presenter.exe")
+    (let* ((exepath (exepath))
            (presenter-path (namestring (asdf:system-relative-pathname :clotho exepath)))
            (presenter-string (format nil "~A --http-port ~A --ws-port ~A"
                                      presenter-path *http-port* *websocket-port*)))
@@ -57,10 +42,10 @@
       (setf *presenter* (uiop:launch-program presenter-string))
       (log-message "presenter started: ~S" (with-output-to-string (out)(describe *presenter* out))))))
 
-#+win32
 (defun quit-presenter ()
   (log-message "sending quit message to presenter")
-  (remote-js:eval *remote-js-context* "presenter.ipcSend('quit')")
+  (with-simple-restart (continue "Ignore error and continue stopping remaining services.")
+    (remote-js:eval *remote-js-context* "presenter.ipcSend('quit')"))
   (log-message "stopping the remote-js context")
   (remote-js:stop *remote-js-context*)
   (log-message "stopping the http server")


### PR DESCRIPTION
As it turns out, all the Windows code was pretty much ready to work on
Linux and MacOS too; all I had to do was change the path of the
executable to run.